### PR TITLE
Allow overriding of the 'delayed::job' label

### DIFF
--- a/app/views/peek/views/_delayed_job.html.erb
+++ b/app/views/peek/views/_delayed_job.html.erb
@@ -1,1 +1,1 @@
-<strong><span data-defer-to="<%= view.defer_key %>-queued">...</span> queued / <span data-defer-to="<%= view.defer_key %>-failed">...</span> failed</strong> delayed::job
+<strong><span data-defer-to="<%= view.defer_key %>-queued">...</span> queued / <span data-defer-to="<%= view.defer_key %>-failed">...</span> failed</strong> <%= view.label %>

--- a/lib/peek/views/delayed_job.rb
+++ b/lib/peek/views/delayed_job.rb
@@ -2,6 +2,11 @@ module Peek
   module Views
     class DelayedJob < View
       def initialize(options = {})
+        @label = options.delete(:label)
+      end
+
+      def label
+        @label || 'delayed::job'
       end
 
       def queued_count


### PR DESCRIPTION
This provides the ability to override the label that is used within peek as not
everyone will be wanting to use 'delayed::job'.

Example usage:

```
Peek.into Peek::Views::DelayedJob, :label => 'DJ'
```
